### PR TITLE
feat: use a fallback loader animation rather than "not found"

### DIFF
--- a/examples/todomvc/src/App.css
+++ b/examples/todomvc/src/App.css
@@ -79,6 +79,25 @@
   background-size: 400% 400%;
 }
 
+.fallback-loader {
+  opacity: 25%;
+  animation-name: flicker;
+  animation-duration:50ms;
+  animation-delay:500ms;
+  animation-timing-function: ease-in;
+  animation-iteration-count: infinite;
+  animation-direction: alternate;
+}
+
+@keyframes flicker{
+  0%   {transform: rotate(-1deg);}
+  20%  {transform: rotate(1deg);}
+  40%  {transform: rotate(-1deg);}
+  60%  {transform: rotate(1deg) scaleY(1.04);}
+  80%  {transform: rotate(-2deg) scaleY(0.92);}
+  100% {transform: rotate(1deg);}
+}
+
 html {
   animation: gradient 20s ease infinite;
 }

--- a/examples/todomvc/src/App.tsx
+++ b/examples/todomvc/src/App.tsx
@@ -233,6 +233,14 @@ const NotFound = () => {
   )
 }
 
+const FallbackLoader = () => {
+  return (
+    <div>
+      <img src='/flame.svg' className='fallback-loader'/>
+    </div>
+  )
+}
+
 interface ListLoaderData {
   list: ListDoc
   todos: TodoDoc[]
@@ -281,7 +289,7 @@ function App() {
     ),{basename: pageBase});
   return (
     <FireproofCtx.Provider value={fireproof}>
-      <RouterProvider router={router} fallbackElement={<NotFound />}  />
+      <RouterProvider router={router} fallbackElement={<FallbackLoader />}  />
     </FireproofCtx.Provider>
   )
 }


### PR DESCRIPTION
per docs here:

https://reactrouter.com/en/main/routers/router-provider#fallbackelement

fallbackElement is intended to be used with a loader animation. If we want this to not show up at all, it may be better to use something like remix or Next.js for this example rather than rolling our own routing.