### PR TITLE
Undef-fields

### DIFF
--- a/packages/fireproof/src/database.js
+++ b/packages/fireproof/src/database.js
@@ -277,11 +277,13 @@ export class Database {
    * @memberof Fireproof
    * @instance
    */
-  async put ({ _id, _proof, ...doc }) {
+  async put ({ _id, _proof, _clock, ...doc }) {
     await this.ready
     const id = _id || 'f' + Math.random().toString(36).slice(2)
+    doc = JSON.parse(JSON.stringify(doc))
+    if (_clock) doc._clock = _clock
     await this.runValidation({ _id: id, ...doc })
-    return await this.putToProllyTree({ key: id, value: doc }, doc._clock)
+    return await this.putToProllyTree({ key: id, value: doc }, _clock)
   }
 
   /**

--- a/packages/fireproof/test/fireproof.test.js
+++ b/packages/fireproof/test/fireproof.test.js
@@ -58,6 +58,12 @@ describe('Fireproof', () => {
     const put2 = await database.put({ _id: null, field: 'foo' })
     assert.notEqual(put2.id, null)
   })
+  it('only put document with undefined field', async () => {
+    assert(resp0.id, 'should have id')
+    assert.equal(resp0.id, '1ef3b32a-3c3a-4b5e-9c1c-8c5c0c5c0c5c')
+    const put2 = await database.put({ _id: 'undef', field: undefined })
+    assert.notEqual(put2.id, null)
+  })
   it('mvcc put and get document with _clock that matches', async () => {
     assert(resp0.clock, 'should have clock')
     assert.equal(resp0.clock.length, 1)


### PR DESCRIPTION
we should just handle this for the user instead of making it have a nasty crash. we should delete undefined fields instead of serializing them.